### PR TITLE
Create requirements.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ python dependencies:
 
 sys, opencv, numpy, pytessetact, math, csv, tqdm and PIL.
 
-All dependancies may be installed using pip or pip3 as such:
-<code> pip3 install os-sys opencv-python numpy pytesseract python-math python-csv tqdm pillow </code>
+All dependancies may be installed using the following command:
+<code> pip3 install -r "requirements.txt" </code>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+colorama==0.4.6
+numpy==1.24.2
+opencv-python==4.7.0.72
+packaging==23.0
+Pillow==9.4.0
+pytesseract==0.3.10
+tqdm==4.64.1


### PR DESCRIPTION
In Python, it is common practice to create a "requirements.txt" file that lists all the dependencies required for your project. By doing so, you can simply run the command "pip install -r requirements.txt" instead of manually specifying each dependency. 